### PR TITLE
Fixing issue #66.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -100,7 +100,7 @@ describe "The String 'Hello World'"{
 						<h3>Specify executable scenarios</h3>
 						<p>
 							You can write executable acceptance specifications
-							similiar to <a href="http://www.cukes.info">Cucumber</a>, but
+							similiar to <a href="http://cukes.info/">Cucumber</a>, but
 							with less maintenance overhead.
 						</p>
 					</div>


### PR DESCRIPTION
The link to the Cucumber homepage was broken. 
Fixed the pointing from http://www.cukes.info/ to http://cukes.info/.
