### PR TITLE
org.jnario.spec: Remove unneeded dep. to org.eclipse.xtext.xbase.ui

### DIFF
--- a/plugins/org.jnario.suite/META-INF/MANIFEST.MF
+++ b/plugins/org.jnario.suite/META-INF/MANIFEST.MF
@@ -24,7 +24,6 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xbase.lib,
  org.jnario;bundle-version="1.0.0",
  org.jnario.lib;bundle-version="1.0.0",
- org.eclipse.xtext.xbase.ui;bundle-version="[2.6.1,2.7.0)",
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.xbase.lib


### PR DESCRIPTION
This prevents a whole bunch of eclipse UI plugins to be needed for
a headless build.
