### PR TITLE
#137 Unknown variable within should_be_null => NullPointerException

### DIFF
--- a/plugins/org.jnario/src/org/jnario/typing/JnarioTypeComputer.java
+++ b/plugins/org.jnario/src/org/jnario/typing/JnarioTypeComputer.java
@@ -69,9 +69,8 @@ public class JnarioTypeComputer extends XtendTypeComputer {
 					}
 				}
 			}
-		} else {
-			super._computeTypes(featureCall, state);
 		}
+		super._computeTypes(featureCall, state);
 	}
 
 	private boolean canHandleNullArg(JvmOperation operation) {

--- a/tests/org.jnario.tests/doc-gen/org/jnario/JnarioSuite.html
+++ b/tests/org.jnario.tests/doc-gen/org/jnario/JnarioSuite.html
@@ -127,6 +127,7 @@
 	<li><a class="specref notrun" href="../../org/jnario/spec/tests/unit/naming/ExampleNameProviderSpec.html">ExampleNameProvider</a></li>
 	<li><a class="specref notrun" href="../../org/jnario/spec/tests/integration/ImplicitSubjectSpec.html">Implicit Subject</a></li>
 	<li><a class="specref notrun" href="../../org/jnario/spec/tests/documentation/IntroducingJnarioSpecsSpec.html">Introducing Jnario Specs</a></li>
+	<li><a class="specref notrun" href="../../org/jnario/spec/tests/unit/validation/LinkerValidationSpec.html">Linker validation</a></li>
 	<li><a class="specref pending" href="../../org/jnario/spec/tests/integration/MockingSpec.html">Mocking</a> <strong class="icon pending">~</strong></li>
 	<li><a class="specref notrun" href="../../org/jnario/spec/tests/unit/naming/OperationNameProviderSpec.html">OperationNameProvider</a></li>
 	<li><a class="specref notrun" href="../../org/jnario/spec/tests/integration/PendingSpec.html">Pending</a></li>

--- a/tests/org.jnario.tests/doc-gen/org/jnario/spec/tests/unit/validation/LinkerValidationSpec.html
+++ b/tests/org.jnario.tests/doc-gen/org/jnario/spec/tests/unit/validation/LinkerValidationSpec.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Linker validation</title>
+<meta name="description" content="">
+<meta name="author" content="Jnario">
+
+<!--[if lt IE 9]>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+<link rel="stylesheet" href="../../../../../../css/bootstrap.min.css">
+<link rel="stylesheet" href="../../../../../../css/bootstrap-responsive.min.css">
+<link rel="stylesheet" href="../../../../../../css/custom.css">
+<link rel="stylesheet" href="../../../../../../css/prettify.css">
+<script type="text/javascript" src="../../../../../../js/prettify.js"></script>
+<script type="text/javascript" src="../../../../../../js/lang-jnario.js"></script>
+<script type="text/javascript" src="../../../../../../js/jquery.js"></script>
+<script type="text/javascript" src="../../../../../../js/bootstrap-tab.js"></script>
+</head>
+
+<body onload="prettyPrint()">
+	<div class="container">
+		<div class="tabbable">
+			<div class="content">
+				<div class="page-header notrun">
+					<h1>Linker validation</h1>
+					  <ul class="nav nav-tabs pull-right">
+					    <li class="active"><a href="#spec" data-toggle="tab">Spec</a></li>
+						<li><a href="#source" data-toggle="tab">Source</a></li>
+					  </ul>
+				</div>
+				<div class="row">
+					<div class="span12">
+						  <div class="tab-content">
+							  	<div class="tab-pane active" id="spec">
+<ul><li><p id="No_validation_errors" class="example notrun"><strong>No validation errors</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      1 should not be 2
+    }
+  }
+'''.parse.validate.assertNoIssues</pre>
+</li><li><p id="Unknown_variable" class="example notrun"><strong>Unknown variable</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      println(abc)
+    }
+  }
+'''.parse.validate.assertIssues(
+  &quot;The method or field abc is undefined&quot;
+)</pre>
+</li><li><p id="Unknown_variable_within_should_be_0" class="example notrun"><strong>Unknown variable within should_be_0</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      abc should be 0
+    }
+  }
+'''.parse.validate.assertIssues(
+  &quot;The method or field abc is undefined&quot;
+)</pre>
+</li><li><p id="Unknown_variable_within_should_be_null_Bug_137" class="example notrun"><strong>Unknown variable within should_be_null [Bug -137]</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      abc should be null
+    }
+  }
+'''.parse.validate.assertIssues(
+  &quot;The method or field abc is undefined&quot;
+)</pre>
+</li><li><p id="Unknown_variable_within_null" class="example notrun"><strong>Unknown variable within => null</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      abc =&gt; null
+    }
+  }
+'''.parse.validate.assertIssues(
+  &quot;The method or field abc is undefined&quot;
+)</pre>
+</li><li><p id="Method_call_with_should_be_null" class="example notrun"><strong>Method call with should be null</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      string =&gt; null
+    }
+    def getString() {&quot;&quot;}
+  }
+'''.parse.validate.assertNoIssues</pre>
+</li><li><p id="Null_variable_with_should_be_null" class="example notrun"><strong>Null variable with should be null</strong></p>
+<pre class="prettyprint lang-spec linenums">
+'''
+  package bootstrap
+
+  describe &quot;something&quot;{
+    fact &quot;x&quot; {
+      val withoutType = null
+      withoutType =&gt; null
+    }
+  }
+'''.parse.validate.assertNoIssues</pre>
+</li></ul>
+							</div>
+						    <div class="tab-pane" id="source">
+						    	<h3>SpecLinkerValidation.spec</h3>
+						    	<p>
+<pre class="prettyprint lang-spec linenums">
+package org.jnario.spec.tests.unit.validation
+
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.junit4.util.ParseHelper
+import org.eclipse.xtext.junit4.validation.ValidationTestHelper
+import org.eclipse.xtext.validation.Issue
+import org.jnario.jnario.test.util.SpecTestCreator
+import org.jnario.runner.CreateWith
+import org.junit.Assert
+
+@CreateWith(typeof(SpecTestCreator))
+describe &quot;Linker validation&quot;{
+  @Inject extension ParseHelper&lt; EObject &gt; parseHelper
+  @Inject extension ValidationTestHelper validationTestHelper
+
+  fact &quot;No validation errors&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          1 should not be 2
+        }
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  fact &quot;Unknown variable&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          println(abc)
+        }
+      }
+    '''.parse.validate.assertIssues(
+      &quot;The method or field abc is undefined&quot;
+    )
+  }
+
+  fact &quot;Unknown variable within should_be_0&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          abc should be 0
+        }
+      }
+    '''.parse.validate.assertIssues(
+      &quot;The method or field abc is undefined&quot;
+    )
+  }
+
+  fact &quot;Unknown variable within should_be_null (Bug #137)&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          abc should be null
+        }
+      }
+    '''.parse.validate.assertIssues(
+      &quot;The method or field abc is undefined&quot;
+    )
+  }
+
+  fact &quot;Unknown variable within =&gt; null&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          abc =&gt; null
+        }
+      }
+    '''.parse.validate.assertIssues(
+      &quot;The method or field abc is undefined&quot;
+    )
+  }
+
+  fact &quot;Method call with should be null&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          string =&gt; null
+        }
+        def getString() {&quot;&quot;}
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  fact &quot;Null variable with should be null&quot;{
+    '''
+      package bootstrap
+
+      describe &quot;something&quot;{
+        fact &quot;x&quot; {
+          val withoutType = null
+          withoutType =&gt; null
+        }
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  def assertNoIssues(List&lt;Issue&gt; issues) {
+    issues.size =&gt; 0
+  }
+
+  def assertIssues(List&lt;Issue&gt; issues, String ... parts) {
+    val sb = new StringBuilder
+  for (issue : issues.filter[!parts.exists[part| message.contains(part)]]) {
+    sb.append(&quot;- unmatched actual issue: &quot;)
+    sb.append(issue)
+    sb.append(System.getProperty(&quot;line.separator&quot;))
+  }
+  for (part : parts.filter[part | !issues.exists[message.contains(part)]]) {
+    sb.append(&quot;- unmatched expected issue part: &quot;)
+    sb.append(part)
+    sb.append(System.getProperty(&quot;line.separator&quot;))
+  }
+  if (sb.length &gt; 0) {
+    Assert.fail('''
+      Issue mismatch
+      &laquo;sb.toString&raquo;
+    ''');
+  }
+  }
+
+}
+</pre>
+						    </p></div>
+						  </div>
+					</div> 
+				</div> <!-- /row -->
+			</div> <!-- /content -->
+		</div> <!-- /tabbable -->
+		<footer>
+			<p><small>Generated by <a href="http://www.jnario.org">Jnario</a>.</small></p>
+		</footer>
+	</div> <!-- /container -->
+
+</body>
+</html>

--- a/tests/org.jnario.tests/src/org/jnario/spec/tests/unit/validation/SpecLinkerValidation.spec
+++ b/tests/org.jnario.tests/src/org/jnario/spec/tests/unit/validation/SpecLinkerValidation.spec
@@ -1,0 +1,136 @@
+package org.jnario.spec.tests.unit.validation
+
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.junit4.util.ParseHelper
+import org.eclipse.xtext.junit4.validation.ValidationTestHelper
+import org.eclipse.xtext.validation.Issue
+import org.jnario.jnario.test.util.SpecTestCreator
+import org.jnario.runner.CreateWith
+import org.junit.Assert
+
+@CreateWith(typeof(SpecTestCreator))
+describe "Linker validation"{
+  @Inject extension ParseHelper< EObject > parseHelper
+  @Inject extension ValidationTestHelper validationTestHelper
+
+  fact "No validation errors"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          1 should not be 2
+        }
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  fact "Unknown variable"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          println(abc)
+        }
+      }
+    '''.parse.validate.assertIssues(
+    	"The method or field abc is undefined"
+    )
+  }
+
+  fact "Unknown variable within should_be_0"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          abc should be 0
+        }
+      }
+    '''.parse.validate.assertIssues(
+    	"The method or field abc is undefined"
+    )
+  }
+
+  fact "Unknown variable within should_be_null (Bug #137)"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          abc should be null
+        }
+      }
+    '''.parse.validate.assertIssues(
+    	"The method or field abc is undefined"
+    )
+  }
+
+  fact "Unknown variable within => null"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          abc => null
+        }
+      }
+    '''.parse.validate.assertIssues(
+    	"The method or field abc is undefined"
+    )
+  }
+
+  fact "Method call with should be null"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          string => null
+        }
+        def getString() {""}
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  fact "Null variable with should be null"{
+    '''
+      package bootstrap
+
+      describe "something"{
+        fact "x" {
+          val withoutType = null
+          withoutType => null
+        }
+      }
+    '''.parse.validate.assertNoIssues
+  }
+
+  def assertNoIssues(List<Issue> issues) {
+  	issues.size => 0
+  }
+
+  def assertIssues(List<Issue> issues, String ... parts) {
+  	val sb = new StringBuilder
+	for (issue : issues.filter[!parts.exists[part| message.contains(part)]]) {
+		sb.append("- unmatched actual issue: ")
+		sb.append(issue)
+		sb.append(System.getProperty("line.separator"))
+	}
+	for (part : parts.filter[part | !issues.exists[message.contains(part)]]) {
+		sb.append("- unmatched expected issue part: ")
+		sb.append(part)
+		sb.append(System.getProperty("line.separator"))
+	}
+	if (sb.length > 0) {
+		Assert.fail('''
+			Issue mismatch
+			«sb.toString»
+		''');
+	}
+  }
+
+}

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/SpecSuite.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/SpecSuite.java
@@ -30,11 +30,12 @@ import org.jnario.spec.tests.unit.naming.OperationNameProviderSpec;
 import org.jnario.spec.tests.unit.naming.SpecQualifiedNameProviderSpec;
 import org.jnario.spec.tests.unit.scoping.SpecScopeProviderSpec;
 import org.jnario.spec.tests.unit.spec.SpecExecutableProviderSpec;
+import org.jnario.spec.tests.unit.validation.LinkerValidationSpec;
 import org.jnario.spec.tests.unit.validation.SpecJavaValidatorSpec;
 import org.junit.runner.RunWith;
 
 @Named("Spec")
-@Contains({ AnnotationsSpec.class, AssertionSpec.class, CompilerSpec.class, CustomizingTheSpecCreationSpec.class, DefiningSpecBaseClassesSpec.class, DefiningXtendClassesInYourSpecsSpec.class, ExampleSpec.class, ExampleGroupSpec.class, ExampleNameProviderSpec.class, ImplicitSubjectSpec.class, IntroducingJnarioSpecsSpec.class, MockingSpec.class, OperationNameProviderSpec.class, PendingSpec.class, SetupTeardownSpec.class, SpecExtensionsSpec.class, SpecDocGeneratorSpec.class, SpecExecutableProviderSpec.class, SpecJavaValidatorSpec.class, SpecQualifiedNameProviderSpec.class, SpecsSpec.class, SpecScopeProviderSpec.class, StaticImportsSpec.class, ThrowsSpec.class, UsingJUnitRulesInSpecsSpec.class, UsingShouldSpec.class, UsingTablesSpec.class, UsingXtendSWithOperatorSpec.class })
+@Contains({ AnnotationsSpec.class, AssertionSpec.class, CompilerSpec.class, CustomizingTheSpecCreationSpec.class, DefiningSpecBaseClassesSpec.class, DefiningXtendClassesInYourSpecsSpec.class, ExampleSpec.class, ExampleGroupSpec.class, ExampleNameProviderSpec.class, ImplicitSubjectSpec.class, IntroducingJnarioSpecsSpec.class, LinkerValidationSpec.class, MockingSpec.class, OperationNameProviderSpec.class, PendingSpec.class, SetupTeardownSpec.class, SpecExtensionsSpec.class, SpecDocGeneratorSpec.class, SpecExecutableProviderSpec.class, SpecJavaValidatorSpec.class, SpecQualifiedNameProviderSpec.class, SpecsSpec.class, SpecScopeProviderSpec.class, StaticImportsSpec.class, ThrowsSpec.class, UsingJUnitRulesInSpecsSpec.class, UsingShouldSpec.class, UsingTablesSpec.class, UsingXtendSWithOperatorSpec.class })
 @RunWith(ExampleGroupRunner.class)
 @SuppressWarnings("all")
 public class SpecSuite {

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/spec/tests/unit/validation/LinkerValidationSpec.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/spec/tests/unit/validation/LinkerValidationSpec.java
@@ -1,0 +1,296 @@
+package org.jnario.spec.tests.unit.validation;
+
+import com.google.inject.Inject;
+import java.util.List;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.junit4.util.ParseHelper;
+import org.eclipse.xtext.junit4.validation.ValidationTestHelper;
+import org.eclipse.xtext.validation.Issue;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.jnario.jnario.test.util.SpecTestCreator;
+import org.jnario.lib.Assert;
+import org.jnario.lib.Should;
+import org.jnario.runner.CreateWith;
+import org.jnario.runner.ExampleGroupRunner;
+import org.jnario.runner.Named;
+import org.jnario.runner.Order;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@CreateWith(SpecTestCreator.class)
+@Named("Linker validation")
+@RunWith(ExampleGroupRunner.class)
+@SuppressWarnings("all")
+public class LinkerValidationSpec {
+  @Inject
+  @Extension
+  @org.jnario.runner.Extension
+  public ParseHelper<EObject> parseHelper;
+  
+  @Inject
+  @Extension
+  @org.jnario.runner.Extension
+  public ValidationTestHelper validationTestHelper;
+  
+  @Test
+  @Named("No validation errors")
+  @Order(1)
+  public void _noValidationErrors() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("1 should not be 2");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertNoIssues(_validate);
+  }
+  
+  @Test
+  @Named("Unknown variable")
+  @Order(2)
+  public void _unknownVariable() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("println(abc)");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertIssues(_validate, 
+      "The method or field abc is undefined");
+  }
+  
+  @Test
+  @Named("Unknown variable within should_be_0")
+  @Order(3)
+  public void _unknownVariableWithinShouldBe0() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("abc should be 0");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertIssues(_validate, 
+      "The method or field abc is undefined");
+  }
+  
+  @Test
+  @Named("Unknown variable within should_be_null [Bug -137]")
+  @Order(4)
+  public void _unknownVariableWithinShouldBeNullBug137() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("abc should be null");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertIssues(_validate, 
+      "The method or field abc is undefined");
+  }
+  
+  @Test
+  @Named("Unknown variable within => null")
+  @Order(5)
+  public void _unknownVariableWithinNull() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("abc => null");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertIssues(_validate, 
+      "The method or field abc is undefined");
+  }
+  
+  @Test
+  @Named("Method call with should be null")
+  @Order(6)
+  public void _methodCallWithShouldBeNull() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("string => null");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def getString() {\"\"}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertNoIssues(_validate);
+  }
+  
+  @Test
+  @Named("Null variable with should be null")
+  @Order(7)
+  public void _nullVariableWithShouldBeNull() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package bootstrap");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("describe \"something\"{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("fact \"x\" {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("val withoutType = null");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("withoutType => null");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    EObject _parse = this.parseHelper.parse(_builder);
+    List<Issue> _validate = this.validationTestHelper.validate(_parse);
+    this.assertNoIssues(_validate);
+  }
+  
+  public boolean assertNoIssues(final List<Issue> issues) {
+    int _size = issues.size();
+    Assert.assertTrue("\nExpected issues.size => 0 but"
+     + "\n     issues.size is " + new org.hamcrest.StringDescription().appendValue(Integer.valueOf(_size)).toString()
+     + "\n     issues is " + new org.hamcrest.StringDescription().appendValue(issues).toString() + "\n", Should.<Integer>operator_doubleArrow(Integer.valueOf(_size), Integer.valueOf(0)));
+    
+    return Should.<Integer>operator_doubleArrow(Integer.valueOf(_size), Integer.valueOf(0));
+  }
+  
+  public void assertIssues(final List<Issue> issues, final String... parts) {
+    final StringBuilder sb = new StringBuilder();
+    final Function1<Issue, Boolean> _function = new Function1<Issue, Boolean>() {
+      public Boolean apply(final Issue it) {
+        final Function1<String, Boolean> _function = new Function1<String, Boolean>() {
+          public Boolean apply(final String part) {
+            String _message = it.getMessage();
+            return Boolean.valueOf(_message.contains(part));
+          }
+        };
+        boolean _exists = IterableExtensions.<String>exists(((Iterable<String>)Conversions.doWrapArray(parts)), _function);
+        return Boolean.valueOf((!_exists));
+      }
+    };
+    Iterable<Issue> _filter = IterableExtensions.<Issue>filter(issues, _function);
+    for (final Issue issue : _filter) {
+      {
+        sb.append("- unmatched actual issue: ");
+        sb.append(issue);
+        String _property = System.getProperty("line.separator");
+        sb.append(_property);
+      }
+    }
+    final Function1<String, Boolean> _function_1 = new Function1<String, Boolean>() {
+      public Boolean apply(final String part) {
+        final Function1<Issue, Boolean> _function = new Function1<Issue, Boolean>() {
+          public Boolean apply(final Issue it) {
+            String _message = it.getMessage();
+            return Boolean.valueOf(_message.contains(part));
+          }
+        };
+        boolean _exists = IterableExtensions.<Issue>exists(issues, _function);
+        return Boolean.valueOf((!_exists));
+      }
+    };
+    Iterable<String> _filter_1 = IterableExtensions.<String>filter(((Iterable<String>)Conversions.doWrapArray(parts)), _function_1);
+    for (final String part : _filter_1) {
+      {
+        sb.append("- unmatched expected issue part: ");
+        sb.append(part);
+        String _property = System.getProperty("line.separator");
+        sb.append(_property);
+      }
+    }
+    int _length = sb.length();
+    boolean _greaterThan = (_length > 0);
+    if (_greaterThan) {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Issue mismatch");
+      _builder.newLine();
+      String _string = sb.toString();
+      _builder.append(_string, "");
+      _builder.newLineIfNotEmpty();
+      org.junit.Assert.fail(_builder.toString());
+    }
+  }
+}


### PR DESCRIPTION
I'm not 100% sure about falling through into `super._computeTypes(featureCall, state);`. But it looks, like Xtext can handle most of the cases pretty good now. We just have to interfere only if the choice isn't obvious (like in the new `fact "Method call with should be null"`)
