### PR TITLE
Fix feature links in standalone report generator.

### DIFF
--- a/plugins/org.jnario.standalone/src/org/jnario/compiler/DocCompilerMain.xtend
+++ b/plugins/org.jnario.standalone/src/org/jnario/compiler/DocCompilerMain.xtend
@@ -85,6 +85,7 @@ class DocCompilerMain {
 			jnarioCompiler.setClassPath(classPath);
 			jnarioCompiler.setFileEncoding(fileEncoding);
 			jnarioCompiler.setSourcePath(sourcePath);
+			resourceSet.get().eAdapters().clear();
 			jnarioCompiler.setResourceSetProvider(resourceSet);
 			jnarioCompiler.setExecutable2ResultMapping(createSpec2ResultMapping)
 			if(!jnarioCompiler.compile()){


### PR DESCRIPTION
tl;dr: clear the adapters on the resource set in DocCompilerMain before each doc run so feature links in suite reports are generated.

---

When the standalone report generator (DocCompilerMain) is used (standalone or via ReportTask) with a project that:
- has spec files
- has feature files
- has a suite file that links both spec and feature

... then the generated suite report will not have links to the feature files.
Using the Maven Jnario report plugin in the same project generates the report as expected.
Executing the standalone doc compiler from Eclipse using the latest master has the same problem.

After some debugging it appears this is an issue resolving the SpecReference proxies, and I can make the standalone doc compiler work by changing the `installJvmTypeProvider(resourceSet, classDirectory, true)` to ``in`org.jnario.compiler.JnarioDocCompiler.loadResources()`.
The Maven report plugin uses JnarioDocCompiler as well though, so that just looks like a coincidental fix.
The links to the first type of doc processed (spec by default) work - changing the order of setups to process features first make feature links work and spec links break.

Clearing the adapters on the resource set prior to each type of doc compile (which is what the Maven plugin does) seems to resolve the issue.

Since I'm not 100% on this XTend stuff this might not be the optimal fix, so I've uploaded an example project that demonstrates the issue (includes an Ant based report task) at https://github.com/timw/Jnario/tree/bug-report/generate-docs/tests/generate.docs
