### PR TITLE
Fix #145 (Define 2 and more Xtend classes within Spec)

### DIFF
--- a/plugins/org.jnario.spec/src/org/jnario/spec/naming/ExampleNameProvider.java
+++ b/plugins/org.jnario.spec/src/org/jnario/spec/naming/ExampleNameProvider.java
@@ -93,6 +93,9 @@ public class ExampleNameProvider extends JnarioNameProvider{
 		if (eObject instanceof ExampleTable) {
 			return _toJavaClassName((ExampleTable) eObject);
 		}
+		if (eObject instanceof XtendClass) {
+			return ((XtendClass)eObject).getName();
+		}
 		ExampleGroup exampleGroup = getContainerOfType(eObject, ExampleGroup.class);
 		if(exampleGroup == null){
 			return null;

--- a/tests/org.jnario.tests/doc-gen/org/jnario/spec/tests/unit/validation/SpecJavaValidatorSpec.html
+++ b/tests/org.jnario.tests/doc-gen/org/jnario/spec/tests/unit/validation/SpecJavaValidatorSpec.html
@@ -95,6 +95,25 @@ parseSpec('
 ')
 val validationResult = validate(typeof(XBinaryOperation))
 validationResult.assertOK</pre>
+</li><li><p id="should_can_define_two_classes_in_a_spec" class="example notrun"><strong>should can define two classes in a spec</strong></p>
+<pre class="prettyprint lang-spec linenums">
+parseSpec('
+  class A {}
+  class B {}
+  describe &quot;A&quot;{
+  }
+')
+val validationResult = validate(typeof(SpecFile))
+validationResult.assertOK</pre>
+</li><li><p id="should_can_find_clashes_with_Xtend_classes" class="example notrun"><strong>should can find clashes with Xtend classes</strong></p>
+<pre class="prettyprint lang-spec linenums">
+parseSpec('
+  class ExampleSpec {}
+  describe &quot;Example&quot;{
+  }
+')
+val validationResult = validate(typeof(SpecFile))
+validationResult.assertErrorContains(&quot;type Example is already defined&quot;)</pre>
 </li></ul>
 							</div>
 						    <div class="tab-pane" id="source">
@@ -128,6 +147,7 @@ import org.jnario.jnario.test.util.Resources
 import org.jnario.ExampleCell
 import org.eclipse.xtext.xbase.XExpression
 import org.junit.Ignore
+import org.jnario.spec.spec.SpecFile
 
 @CreateWith(typeof(SpecTestCreator))
 describe SpecJavaValidator{
@@ -270,6 +290,25 @@ describe SpecJavaValidator{
     validationResult.assertOK
   }
   
+  fact &quot;should can define two classes in a spec&quot; {
+    parseSpec('
+      class A {}
+      class B {}
+      describe &quot;A&quot;{
+      }
+    ')
+    val validationResult = validate(typeof(SpecFile))
+    validationResult.assertOK
+  }
+  fact &quot;should can find clashes with Xtend classes&quot; {
+    parseSpec('
+      class ExampleSpec {}
+      describe &quot;Example&quot;{
+      }
+    ')
+    val validationResult = validate(typeof(SpecFile))
+    validationResult.assertErrorContains(&quot;type Example is already defined&quot;)
+  }
   def validate(Class&lt;? extends EObject&gt; type){
     Resources::addContainerStateAdapter(resourceSet);
     val target = query(modelStore).first(type)

--- a/tests/org.jnario.tests/src/org/jnario/spec/tests/unit/validation/SpecJavaValidator.spec
+++ b/tests/org.jnario.tests/src/org/jnario/spec/tests/unit/validation/SpecJavaValidator.spec
@@ -25,6 +25,7 @@ import org.jnario.jnario.test.util.Resources
 import org.jnario.ExampleCell
 import org.eclipse.xtext.xbase.XExpression
 import org.junit.Ignore
+import org.jnario.spec.spec.SpecFile
 
 @CreateWith(typeof(SpecTestCreator))
 describe SpecJavaValidator{
@@ -167,6 +168,25 @@ describe SpecJavaValidator{
 		validationResult.assertOK
 	}
 	
+  fact "should can define two classes in a spec" {
+    parseSpec('
+      class A {}
+      class B {}
+      describe "A"{
+      }
+    ')
+    val validationResult = validate(typeof(SpecFile))
+    validationResult.assertOK
+  }
+  fact "should can find clashes with Xtend classes" {
+    parseSpec('
+      class ExampleSpec {}
+      describe "Example"{
+      }
+    ')
+    val validationResult = validate(typeof(SpecFile))
+    validationResult.assertErrorContains("type Example is already defined")
+  }
 	def validate(Class<? extends EObject> type){
 		Resources::addContainerStateAdapter(resourceSet);
 		val target = query(modelStore).first(type)

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/spec/tests/unit/validation/SpecJavaValidatorSpec.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/spec/tests/unit/validation/SpecJavaValidatorSpec.java
@@ -26,6 +26,7 @@ import org.jnario.runner.ExampleGroupRunner;
 import org.jnario.runner.Named;
 import org.jnario.runner.Order;
 import org.jnario.spec.spec.ExampleGroup;
+import org.jnario.spec.spec.SpecFile;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -133,6 +134,24 @@ public class SpecJavaValidatorSpec {
     this.modelStore.parseSpec("\r\n\t\t\timport static org.hamcrest.CoreMatchers.*\r\n\t\t\tdescribe \"Example\"{\r\n\t\t\t\tfact 1 => notNullValue\r\n\t\t\t} \r\n\t\t");
     final AssertableDiagnostics validationResult = this.validate(XBinaryOperation.class);
     validationResult.assertOK();
+  }
+  
+  @Test
+  @Named("should can define two classes in a spec")
+  @Order(11)
+  public void _shouldCanDefineTwoClassesInASpec() throws Exception {
+    this.modelStore.parseSpec("\r\n      class A {}\r\n      class B {}\r\n      describe \"A\"{\r\n      }\r\n    ");
+    final AssertableDiagnostics validationResult = this.validate(SpecFile.class);
+    validationResult.assertOK();
+  }
+  
+  @Test
+  @Named("should can find clashes with Xtend classes")
+  @Order(12)
+  public void _shouldCanFindClashesWithXtendClasses() throws Exception {
+    this.modelStore.parseSpec("\r\n      class ExampleSpec {}\r\n      describe \"Example\"{\r\n      }\r\n    ");
+    final AssertableDiagnostics validationResult = this.validate(SpecFile.class);
+    validationResult.assertErrorContains("type Example is already defined");
   }
   
   public AssertableDiagnostics validate(final Class<? extends EObject> type) {


### PR DESCRIPTION
Please review my fix. Can java class name deviate from the Xtend class name?
