### PR TITLE
Fix use of args in feature steps

### DIFF
--- a/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/FeatureUiModule.java
+++ b/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/FeatureUiModule.java
@@ -139,6 +139,7 @@ import org.eclipse.xtext.xbase.ui.launching.JavaElementDelegate;
 import org.eclipse.xtext.xbase.ui.quickfix.JavaTypeQuickfixes;
 import org.eclipse.xtext.xbase.ui.refactoring.ExpressionUtil;
 import org.eclipse.xtext.xbase.ui.validation.XbaseIssueSeveritiesProvider;
+import org.jnario.feature.linking.FeatureLazyLinker;
 import org.jnario.feature.ui.autoedit.FeatureAutoEditStrategyProvider;
 import org.jnario.feature.ui.autoedit.FeatureIndentLineAutoEditStrategy;
 import org.jnario.feature.ui.editor.FeatureDoubleClickStrategyProvider;
@@ -535,7 +536,7 @@ public class FeatureUiModule extends org.jnario.feature.ui.AbstractFeatureUiModu
 	}
 	
 	public Class<? extends ILinker> bindILinker() {
-		return Linker.class;
+		return FeatureLazyLinker.class;
 	}
 	
 	public Class<? extends OutlineWithEditorLinker> bindOutlineWithEditorLinker() {


### PR DESCRIPTION
Use of `args` in feature steps with arguments currently fails with a .feature file compile error - it appears that the `XVariableDeclaration` for `args` is not being generated, and `FeatureLazyLinker` is not being injected into the resources (I'm guessing this is what's intended).

It looks like this got broken at some point, possibly as part of 54b3d6479320da4d1f85edd39971d758eb61b66f.

This is the minimal fix I think to make args work - the use of the module overrides in `org.jnario.feature.ui.internal.FeatureActivator.createInjector(String)` does look a bit fragile (with multiple org.jnario.\* modules declaring the same type of bindings, with the last one winning), but I'm not sure yet how to make it less so.
