### PR TITLE
Fix outline view errors with xtext 2.7

### DIFF
--- a/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/FeatureUiModule.java
+++ b/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/FeatureUiModule.java
@@ -47,6 +47,7 @@ import org.eclipse.xtend.ide.hover.XtendHoverDocumentationProvider;
 import org.eclipse.xtend.ide.hyperlinking.XtendHyperlinkHelper;
 import org.eclipse.xtend.ide.outline.ShowSyntheticMembersContribution;
 import org.eclipse.xtend.ide.outline.XtendOutlineNodeComparator;
+import org.eclipse.xtend.ide.outline.XtendOutlineNodeFactory;
 import org.eclipse.xtend.ide.outline.XtendOutlinePage;
 import org.eclipse.xtend.ide.outline.XtendOutlineWithEditorLinker;
 import org.eclipse.xtend.ide.outline.XtendQuickOutlineFilterAndSorter;
@@ -107,6 +108,7 @@ import org.eclipse.xtext.ui.editor.occurrences.IOccurrenceComputer;
 import org.eclipse.xtext.ui.editor.outline.IOutlineTreeProvider;
 import org.eclipse.xtext.ui.editor.outline.actions.IOutlineContribution;
 import org.eclipse.xtext.ui.editor.outline.actions.OutlineWithEditorLinker;
+import org.eclipse.xtext.ui.editor.outline.impl.OutlineNodeFactory;
 import org.eclipse.xtext.ui.editor.outline.impl.OutlineFilterAndSorter.IComparator;
 import org.eclipse.xtext.ui.editor.outline.quickoutline.QuickOutlineFilterAndSorter;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
@@ -546,4 +548,9 @@ public class FeatureUiModule extends org.jnario.feature.ui.AbstractFeatureUiModu
 	public Class<? extends IOutlineTreeProvider.ModeAware> bindIOutlineTreeProvider_ModeAware() {
 		return org.eclipse.xtend.ide.outline.XtendOutlineModes.class;
 	}
+
+	public Class<? extends OutlineNodeFactory> bindOutlineNodeFactory() {
+		return XtendOutlineNodeFactory.class;
+	}
+	
 }

--- a/plugins/org.jnario.spec.ui/src/org/jnario/spec/ui/SpecUiModule.java
+++ b/plugins/org.jnario.spec.ui/src/org/jnario/spec/ui/SpecUiModule.java
@@ -53,6 +53,7 @@ import org.eclipse.xtend.ide.hover.XtendHoverSignatureProvider;
 import org.eclipse.xtend.ide.hyperlinking.XtendHyperlinkHelper;
 import org.eclipse.xtend.ide.outline.ShowSyntheticMembersContribution;
 import org.eclipse.xtend.ide.outline.XtendOutlineNodeComparator;
+import org.eclipse.xtend.ide.outline.XtendOutlineNodeFactory;
 import org.eclipse.xtend.ide.outline.XtendOutlinePage;
 import org.eclipse.xtend.ide.outline.XtendOutlineWithEditorLinker;
 import org.eclipse.xtend.ide.outline.XtendQuickOutlineFilterAndSorter;
@@ -115,6 +116,7 @@ import org.eclipse.xtext.ui.editor.outline.IOutlineTreeProvider;
 import org.eclipse.xtext.ui.editor.outline.actions.IOutlineContribution;
 import org.eclipse.xtext.ui.editor.outline.actions.OutlineWithEditorLinker;
 import org.eclipse.xtext.ui.editor.outline.impl.OutlineFilterAndSorter.IComparator;
+import org.eclipse.xtext.ui.editor.outline.impl.OutlineNodeFactory;
 import org.eclipse.xtext.ui.editor.outline.quickoutline.QuickOutlineFilterAndSorter;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
@@ -503,7 +505,6 @@ public class SpecUiModule extends org.jnario.spec.ui.AbstractSpecUiModule {
 	public Class<? extends IContentProposalPriorities> bindIContentProposalPriorities() {
 		return XbaseContentProposalPriorities.class;
 	}
-	
 
 	@Override
 	public Class<? extends IProposalConflictHelper> bindIProposalConflictHelper() {
@@ -525,4 +526,10 @@ public class SpecUiModule extends org.jnario.spec.ui.AbstractSpecUiModule {
 	public Class<? extends IOutlineTreeProvider.ModeAware> bindIOutlineTreeProvider_ModeAware() {
 		return org.eclipse.xtend.ide.outline.XtendOutlineModes.class;
 	}
+	
+	public Class<? extends OutlineNodeFactory> bindOutlineNodeFactory() {
+		return XtendOutlineNodeFactory.class;
+	}
+	
+
 }

--- a/plugins/org.jnario.suite.ui/src/org/jnario/suite/ui/SuiteUiModule.java
+++ b/plugins/org.jnario.suite.ui/src/org/jnario/suite/ui/SuiteUiModule.java
@@ -47,6 +47,7 @@ import org.eclipse.xtend.ide.hover.XtendHoverDocumentationProvider;
 import org.eclipse.xtend.ide.hyperlinking.XtendHyperlinkHelper;
 import org.eclipse.xtend.ide.outline.ShowSyntheticMembersContribution;
 import org.eclipse.xtend.ide.outline.XtendOutlineNodeComparator;
+import org.eclipse.xtend.ide.outline.XtendOutlineNodeFactory;
 import org.eclipse.xtend.ide.outline.XtendOutlinePage;
 import org.eclipse.xtend.ide.outline.XtendOutlineWithEditorLinker;
 import org.eclipse.xtend.ide.outline.XtendQuickOutlineFilterAndSorter;
@@ -102,6 +103,7 @@ import org.eclipse.xtext.ui.editor.occurrences.IOccurrenceComputer;
 import org.eclipse.xtext.ui.editor.outline.IOutlineTreeProvider;
 import org.eclipse.xtext.ui.editor.outline.actions.IOutlineContribution;
 import org.eclipse.xtext.ui.editor.outline.actions.OutlineWithEditorLinker;
+import org.eclipse.xtext.ui.editor.outline.impl.OutlineNodeFactory;
 import org.eclipse.xtext.ui.editor.outline.impl.OutlineFilterAndSorter.IComparator;
 import org.eclipse.xtext.ui.editor.outline.quickoutline.QuickOutlineFilterAndSorter;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
@@ -496,4 +498,9 @@ public class SuiteUiModule extends org.jnario.suite.ui.AbstractSuiteUiModule {
 	public Class<? extends IOutlineTreeProvider.ModeAware> bindIOutlineTreeProvider_ModeAware() {
 		return org.eclipse.xtend.ide.outline.XtendOutlineModes.class;
 	}
+
+	public Class<? extends OutlineNodeFactory> bindOutlineNodeFactory() {
+		return XtendOutlineNodeFactory.class;
+	}
+	
 }


### PR DESCRIPTION
Provide binding from OutlineNodeFactory to XtendOutlineNodeFactory so outline view doesn't break in specs/features/suites.

TODO: It might be better to just mixin XTendUIModule?
