### PR TITLE
Propagate ignored/pending status to suite elements in runner

### DIFF
--- a/plugins/org.jnario.ui/src/org/jnario/ui/handler/AbstractJnarioRunnerUIHandler.java
+++ b/plugins/org.jnario.ui/src/org/jnario/ui/handler/AbstractJnarioRunnerUIHandler.java
@@ -5,12 +5,14 @@ import org.eclipse.jdt.internal.junit.model.TestElement;
 import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
 import org.eclipse.jdt.junit.model.ITestCaseElement;
 import org.eclipse.jdt.junit.model.ITestElement;
+import org.eclipse.jdt.junit.model.ITestElementContainer;
 import org.eclipse.jdt.junit.model.ITestSuiteElement;
 import org.eclipse.jdt.junit.runners.IRunnerUIHandler;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.ui.part.ViewPart;
+import org.jnario.util.Strings;
 
 @SuppressWarnings("restriction")
 public abstract class AbstractJnarioRunnerUIHandler implements IRunnerUIHandler {
@@ -40,9 +42,38 @@ public abstract class AbstractJnarioRunnerUIHandler implements IRunnerUIHandler 
 	public String getSimpleLabel(ViewPart part, ITestElement element) {
 		if (element instanceof ITestCaseElement)
 			return ((ITestCaseElement) element).getTestMethodName();
-		if (element instanceof ITestSuiteElement)
-			return AbstractJnarioOpenTestAction.extractTestName((TestElement)element);
+		if (element instanceof ITestSuiteElement) {
+			String baseName = AbstractJnarioOpenTestAction.extractTestName((TestElement)element);
+			if (isAllPendingOrIgnored((TestSuiteElement) element, false)) {
+				return Strings.markAsIgnored(new StringBuilder(baseName)).toString();
+			} else if (isAllPendingOrIgnored((TestSuiteElement) element, true)) {
+				return Strings.markAsPending(new StringBuilder(baseName)).toString();
+			}
+			return baseName;
+		}
 		return "unknown";
+	}
+
+	private boolean isAllPendingOrIgnored(ITestElementContainer element, boolean includePending) {
+		if (element.getChildren().length == 0) {
+			return false;
+		}
+		for (ITestElement child : element.getChildren()) {
+			if (child instanceof TestCaseElement) {
+				if (!((TestCaseElement) child).isIgnored()) {
+					return false;
+				} else if(!includePending && Strings.isMarkedAsPending(((TestCaseElement) child).getTestName())) {
+					return false;
+				}
+			} else if (child instanceof ITestElementContainer) {
+				if (!isAllPendingOrIgnored((ITestElementContainer) child, includePending)) {
+					return false;
+				}
+			} else {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public StyledString getStyledLabel(ViewPart part, ITestElement element,

--- a/plugins/org.jnario/src/org/jnario/util/Strings.java
+++ b/plugins/org.jnario/src/org/jnario/util/Strings.java
@@ -30,6 +30,8 @@ public class Strings extends org.eclipse.xtext.util.Strings{
 	
 	public static final String PENDING_FLAG = " [PENDING]";
 
+	public static final String IGNORED_FLAG = " [IGNORED]";
+	
 	public static int countWhitespaceAtEnd(CharSequence s){
 		int count = 0;
 		for(int j = s.length()-1; j >= 0 && isWhitespace(s.charAt(j)); j--){
@@ -244,6 +246,14 @@ public class Strings extends org.eclipse.xtext.util.Strings{
 		return sb.append(PENDING_FLAG);
 	}
 
+	public static boolean isMarkedAsPending(String str) {
+		return str.contains(PENDING_FLAG);
+	}
+
+	public static StringBuilder markAsIgnored(StringBuilder sb){
+		return sb.append(IGNORED_FLAG);
+	}
+
 	public static String toString(Resource resource) {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		try {
@@ -298,4 +308,5 @@ public class Strings extends org.eclipse.xtext.util.Strings{
 			return result.toString();
 		}
 	}
+
 }

--- a/tests/org.jnario.tests/doc-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSpec.html
+++ b/tests/org.jnario.tests/doc-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSpec.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AbstractJnarioRunnerUIHandler</title>
+<meta name="description" content="">
+<meta name="author" content="Jnario">
+
+<!--[if lt IE 9]>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+<link rel="stylesheet" href="../../../../../../css/bootstrap.min.css">
+<link rel="stylesheet" href="../../../../../../css/bootstrap-responsive.min.css">
+<link rel="stylesheet" href="../../../../../../css/custom.css">
+<link rel="stylesheet" href="../../../../../../css/prettify.css">
+<script type="text/javascript" src="../../../../../../js/prettify.js"></script>
+<script type="text/javascript" src="../../../../../../js/lang-jnario.js"></script>
+<script type="text/javascript" src="../../../../../../js/jquery.js"></script>
+<script type="text/javascript" src="../../../../../../js/bootstrap-tab.js"></script>
+</head>
+
+<body onload="prettyPrint()">
+	<div class="container">
+		<div class="tabbable">
+			<div class="content">
+				<div class="page-header notrun">
+					<h1>AbstractJnarioRunnerUIHandler</h1>
+					  <ul class="nav nav-tabs pull-right">
+					    <li class="active"><a href="#spec" data-toggle="tab">Spec</a></li>
+						<li><a href="#source" data-toggle="tab">Source</a></li>
+					  </ul>
+				</div>
+				<div class="row">
+					<div class="span12">
+						  <div class="tab-content">
+							  	<div class="tab-pane active" id="spec">
+<h3 class="exampleGroup notrun"  id="Suite_Labelling">Suite Labelling</h3>
+<p>JUnit suite names are annotated with [IGNORED] if all child members are ignored and [PENDING] if all child members are ignored and at least one is pending.</p>
+<ul><li><p id="cases"><strong>Cases</strong></p>
+<table class="table table-striped table-bordered table-condensed">
+	<thead>
+		<tr>
+		<th>left</th>
+		<th>right</th>
+		<th>result</th>
+		</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>null</td>
+		<td>null</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>tc</td>
+		<td>null</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>ign</td>
+		<td>null</td>
+		<td>markedIgnored</td>
+	</tr>
+	<tr>
+		<td>pend</td>
+		<td>null</td>
+		<td>markedPending</td>
+	</tr>
+	<tr>
+		<td>tc</td>
+		<td>ign</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>tc</td>
+		<td>pend</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>ign</td>
+		<td>pend</td>
+		<td>markedPending</td>
+	</tr>
+	<tr>
+		<td>ign</td>
+		<td>ign</td>
+		<td>markedIgnored</td>
+	</tr>
+	<tr>
+		<td>suite(tc)</td>
+		<td>pend</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>suite(pend)</td>
+		<td>tc</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>suite(tc)</td>
+		<td>ign</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>suite(ign)</td>
+		<td>tc</td>
+		<td>notMarked</td>
+	</tr>
+	<tr>
+		<td>suite(pend)</td>
+		<td>ign</td>
+		<td>markedPending</td>
+	</tr>
+	<tr>
+		<td>suite(ign)</td>
+		<td>pend</td>
+		<td>markedPending</td>
+	</tr>
+	<tr>
+		<td>suite(ign)</td>
+		<td>ign</td>
+		<td>markedIgnored</td>
+	</tr>
+	</tbody>
+</table>
+</li><li><p id="All_cases" class="example notrun"><strong>All cases</strong></p>
+<pre class="prettyprint lang-spec linenums">
+cases.forEach [
+  val elements = list(left, right).filterNull
+  result.matches(label(root(elements))) should be true
+]</pre>
+</li></ul>
+							</div>
+						    <div class="tab-pane" id="source">
+						    	<h3>AbstractJnarioRunnerUIHandler.spec</h3>
+						    	<p>
+<pre class="prettyprint lang-spec linenums">
+package org.jnario.jnario.tests.unit.ui
+
+import org.eclipse.jdt.internal.junit.model.TestCaseElement
+import org.eclipse.jdt.internal.junit.model.TestElement
+import org.eclipse.jdt.internal.junit.model.TestRoot
+import org.eclipse.jdt.internal.junit.model.TestRunSession
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement
+import org.eclipse.jdt.junit.model.ITestElement
+import org.eclipse.ui.part.ViewPart
+import org.jnario.ui.handler.AbstractJnarioRunnerUIHandler
+import org.jnario.util.Strings
+
+import static org.hamcrest.Matchers.*
+
+class TestUIHandler extends AbstractJnarioRunnerUIHandler {
+
+  override getAction(ViewPart part, ITestElement element) {
+  }
+
+}
+
+describe &quot;AbstractJnarioRunnerUIHandler&quot; {
+
+  /**
+   * JUnit suite names are annotated with [IGNORED] if all child members are ignored
+   * and [PENDING] if all child members are ignored and at least one is pending.
+   */
+  describe &quot;Suite Labelling&quot; {
+    val root = new TestRoot(new TestRunSession(&quot;run&quot;, null))
+    val handler = new TestUIHandler()
+    val ViewPart part = null
+
+    def cases {
+      | left        | right | result        |
+      | null        | null  | notMarked     |
+      | tc          | null  | notMarked     |
+      | ign         | null  | markedIgnored |
+      | pend        | null  | markedPending |
+      | tc          | ign   | notMarked     |
+      | tc          | pend  | notMarked     |
+      | ign         | pend  | markedPending |
+      | ign         | ign   | markedIgnored |
+      | suite(tc)   | pend  | notMarked     |
+      | suite(pend) | tc    | notMarked     |
+      | suite(tc)   | ign   | notMarked     |
+      | suite(ign)  | tc    | notMarked     |
+      | suite(pend) | ign   | markedPending |
+      | suite(ign)  | pend  | markedPending |
+      | suite(ign)  | ign   | markedIgnored |
+    }
+
+    fact &quot;All cases&quot; {
+      cases.forEach [
+        val elements = list(left, right).filterNull
+        result.matches(label(root(elements))) should be true
+      ]
+    }
+
+    def root((TestSuiteElement)=&gt;TestElement... elementConstructors) {
+      suite(elementConstructors).apply(root)
+    }
+
+    def suite((TestSuiteElement)=&gt;TestElement... elementConstructors) {
+      [ TestSuiteElement parent |
+        val suite = new TestSuiteElement(parent, &quot;id&quot;, &quot;name&quot;, 10)
+        elementConstructors.forEach[it.apply(suite)]
+        suite
+      ]
+    }
+
+    def tc() {
+      [TestSuiteElement suite|new TestCaseElement(suite, &quot;id&quot;, &quot;tc&quot;)]
+    }
+
+    def ign() {
+      [ TestSuiteElement suite |
+        tc().apply(suite) =&gt; [
+          name = &quot;tc-ign&quot;
+          ignored = true
+        ]
+      ]
+    }
+
+    def pend() {
+      [ TestSuiteElement suite |
+        ign().apply(suite) =&gt; [
+          name = &quot;tc [PENDING]&quot;
+        ]
+      ]
+    }
+
+    def label(TestSuiteElement suite) {
+      handler.getSimpleLabel(part, suite)
+    }
+
+    def markedPending() {
+      allOf(containsString(Strings::PENDING_FLAG), ^not(containsString(Strings::IGNORED_FLAG)))
+    }
+
+    def markedIgnored() {
+      allOf(containsString(Strings::IGNORED_FLAG), ^not(containsString(Strings::PENDING_FLAG)))
+    }
+
+    def notMarked() {
+      ^not(anyOf(containsString(Strings::IGNORED_FLAG), containsString(Strings::PENDING_FLAG)))
+    }
+  }
+
+}
+</pre>
+						    </p></div>
+						  </div>
+					</div> 
+				</div> <!-- /row -->
+			</div> <!-- /content -->
+		</div> <!-- /tabbable -->
+		<footer>
+			<p><small>Generated by <a href="http://www.jnario.org">Jnario</a>.</small></p>
+		</footer>
+	</div> <!-- /container -->
+
+</body>
+</html>

--- a/tests/org.jnario.tests/src/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandler.spec
+++ b/tests/org.jnario.tests/src/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandler.spec
@@ -1,0 +1,109 @@
+package org.jnario.jnario.tests.unit.ui
+
+import org.eclipse.jdt.internal.junit.model.TestCaseElement
+import org.eclipse.jdt.internal.junit.model.TestElement
+import org.eclipse.jdt.internal.junit.model.TestRoot
+import org.eclipse.jdt.internal.junit.model.TestRunSession
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement
+import org.eclipse.jdt.junit.model.ITestElement
+import org.eclipse.ui.part.ViewPart
+import org.jnario.ui.handler.AbstractJnarioRunnerUIHandler
+import org.jnario.util.Strings
+
+import static org.hamcrest.Matchers.*
+
+class TestUIHandler extends AbstractJnarioRunnerUIHandler {
+
+	override getAction(ViewPart part, ITestElement element) {
+	}
+
+}
+
+describe "AbstractJnarioRunnerUIHandler" {
+
+	/**
+	 * JUnit suite names are annotated with [IGNORED] if all child members are ignored
+	 * and [PENDING] if all child members are ignored and at least one is pending.
+	 */
+	describe "Suite Labelling" {
+		val root = new TestRoot(new TestRunSession("run", null))
+		val handler = new TestUIHandler()
+		val ViewPart part = null
+
+		def cases {
+			| left        | right | result        |
+			| null        | null  | notMarked     |
+			| tc          | null  | notMarked     |
+			| ign         | null  | markedIgnored |
+			| pend        | null  | markedPending |
+			| tc          | ign   | notMarked     |
+			| tc          | pend  | notMarked     |
+			| ign         | pend  | markedPending |
+			| ign         | ign   | markedIgnored |
+			| suite(tc)   | pend  | notMarked     |
+			| suite(pend) | tc    | notMarked     |
+			| suite(tc)   | ign   | notMarked     |
+			| suite(ign)  | tc    | notMarked     |
+			| suite(pend) | ign   | markedPending |
+			| suite(ign)  | pend  | markedPending |
+			| suite(ign)  | ign   | markedIgnored |
+		}
+
+		fact "All cases" {
+			cases.forEach [
+				val elements = list(left, right).filterNull
+				result.matches(label(root(elements))) should be true
+			]
+		}
+
+		def root((TestSuiteElement)=>TestElement... elementConstructors) {
+			suite(elementConstructors).apply(root)
+		}
+
+		def suite((TestSuiteElement)=>TestElement... elementConstructors) {
+			[ TestSuiteElement parent |
+				val suite = new TestSuiteElement(parent, "id", "name", 10)
+				elementConstructors.forEach[it.apply(suite)]
+				suite
+			]
+		}
+
+		def tc() {
+			[TestSuiteElement suite|new TestCaseElement(suite, "id", "tc")]
+		}
+
+		def ign() {
+			[ TestSuiteElement suite |
+				tc().apply(suite) => [
+					name = "tc-ign"
+					ignored = true
+				]
+			]
+		}
+
+		def pend() {
+			[ TestSuiteElement suite |
+				ign().apply(suite) => [
+					name = "tc [PENDING]"
+				]
+			]
+		}
+
+		def label(TestSuiteElement suite) {
+			handler.getSimpleLabel(part, suite)
+		}
+
+		def markedPending() {
+			allOf(containsString(Strings::PENDING_FLAG), ^not(containsString(Strings::IGNORED_FLAG)))
+		}
+
+		def markedIgnored() {
+			allOf(containsString(Strings::IGNORED_FLAG), ^not(containsString(Strings::PENDING_FLAG)))
+		}
+
+		def notMarked() {
+			^not(anyOf(containsString(Strings::IGNORED_FLAG), containsString(Strings::PENDING_FLAG)))
+		}
+	}
+
+}

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSpec.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSpec.java
@@ -1,0 +1,14 @@
+package org.jnario.jnario.tests.unit.ui;
+
+import org.jnario.jnario.tests.unit.ui.AbstractJnarioRunnerUIHandlerSuiteLabellingSpec;
+import org.jnario.runner.Contains;
+import org.jnario.runner.ExampleGroupRunner;
+import org.jnario.runner.Named;
+import org.junit.runner.RunWith;
+
+@Contains(AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.class)
+@Named("AbstractJnarioRunnerUIHandler")
+@RunWith(ExampleGroupRunner.class)
+@SuppressWarnings("all")
+public class AbstractJnarioRunnerUIHandlerSpec {
+}

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.java
@@ -1,0 +1,415 @@
+package org.jnario.jnario.tests.unit.ui;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.model.TestElement;
+import org.eclipse.jdt.internal.junit.model.TestRoot;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
+import org.eclipse.ui.part.ViewPart;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.AnyOf;
+import org.jnario.jnario.tests.unit.ui.AbstractJnarioRunnerUIHandlerSpec;
+import org.jnario.jnario.tests.unit.ui.AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases;
+import org.jnario.jnario.tests.unit.ui.TestUIHandler;
+import org.jnario.lib.Assert;
+import org.jnario.lib.Each;
+import org.jnario.lib.ExampleTable;
+import org.jnario.lib.JnarioCollectionLiterals;
+import org.jnario.lib.Should;
+import org.jnario.runner.ExampleGroupRunner;
+import org.jnario.runner.Named;
+import org.jnario.runner.Order;
+import org.jnario.util.Strings;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * JUnit suite names are annotated with [IGNORED] if all child members are ignored
+ * and [PENDING] if all child members are ignored and at least one is pending.
+ */
+@Named("Suite Labelling")
+@RunWith(ExampleGroupRunner.class)
+@SuppressWarnings("all")
+public class AbstractJnarioRunnerUIHandlerSuiteLabellingSpec extends AbstractJnarioRunnerUIHandlerSpec {
+  final TestRoot root = new TestRoot(new TestRunSession("run", null));
+  
+  final TestUIHandler handler = new TestUIHandler();
+  
+  final ViewPart part = null;
+  
+  public ExampleTable<AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases() {
+    return ExampleTable.create("cases", 
+      Arrays.asList("left", "right", "result"), 
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("null", "null", "notMarked"), null, null, _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell2()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("tc", "null", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell3(), null, _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell5()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("ign", "null", "markedIgnored"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell6(), null, _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell8()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("pend", "null", "markedPending"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell9(), null, _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell11()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("tc", "ign", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell12(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell13(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell14()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("tc", "pend", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell15(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell16(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell17()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("ign", "pend", "markedPending"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell18(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell19(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell20()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("ign", "ign", "markedIgnored"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell21(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell22(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell23()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(tc)", "pend", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell24(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell25(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell26()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(pend)", "tc", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell27(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell28(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell29()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(tc)", "ign", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell30(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell31(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell32()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(ign)", "tc", "notMarked"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell33(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell34(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell35()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(pend)", "ign", "markedPending"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell36(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell37(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell38()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(ign)", "pend", "markedPending"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell39(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell40(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell41()),
+      new AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(  Arrays.asList("suite(ign)", "ign", "markedIgnored"), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell42(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell43(), _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell44())
+    );
+  }
+  
+  protected ExampleTable<AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases> cases = _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases();
+  
+  public Object _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell0() {
+    return null;
+  }
+  
+  public Object _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell1() {
+    return null;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell2() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell3() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    return _tc;
+  }
+  
+  public Object _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell4() {
+    return null;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell5() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell6() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Object _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell7() {
+    return null;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell8() {
+    Matcher<String> _markedIgnored = this.markedIgnored();
+    return _markedIgnored;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell9() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    return _pend;
+  }
+  
+  public Object _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell10() {
+    return null;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell11() {
+    Matcher<String> _markedPending = this.markedPending();
+    return _markedPending;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell12() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    return _tc;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell13() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell14() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell15() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    return _tc;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell16() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    return _pend;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell17() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell18() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell19() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    return _pend;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell20() {
+    Matcher<String> _markedPending = this.markedPending();
+    return _markedPending;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell21() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell22() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell23() {
+    Matcher<String> _markedIgnored = this.markedIgnored();
+    return _markedIgnored;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell24() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_tc);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell25() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    return _pend;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell26() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell27() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_pend);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell28() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    return _tc;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell29() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell30() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_tc);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell31() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell32() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell33() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_ign);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell34() {
+    Function1<TestSuiteElement, TestCaseElement> _tc = this.tc();
+    return _tc;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell35() {
+    Matcher<String> _notMarked = this.notMarked();
+    return _notMarked;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell36() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_pend);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell37() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell38() {
+    Matcher<String> _markedPending = this.markedPending();
+    return _markedPending;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell39() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_ign);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell40() {
+    Function1<TestSuiteElement, TestCaseElement> _pend = this.pend();
+    return _pend;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell41() {
+    Matcher<String> _markedPending = this.markedPending();
+    return _markedPending;
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell42() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(_ign);
+    return _suite;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell43() {
+    Function1<TestSuiteElement, TestCaseElement> _ign = this.ign();
+    return _ign;
+  }
+  
+  public Matcher<String> _initAbstractJnarioRunnerUIHandlerSuiteLabellingSpecCasesCell44() {
+    Matcher<String> _markedIgnored = this.markedIgnored();
+    return _markedIgnored;
+  }
+  
+  @Test
+  @Named("All cases")
+  @Order(1)
+  public void _allCases() throws Exception {
+    final Procedure1<AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases> _function = new Procedure1<AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases>() {
+      public void apply(final AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases it) {
+        Function1<TestSuiteElement, ? extends TestElement> _left = it.getLeft();
+        Function1<TestSuiteElement, TestCaseElement> _right = it.getRight();
+        List<Function1<TestSuiteElement, ? extends TestElement>> _list = JnarioCollectionLiterals.<Function1<TestSuiteElement, ? extends TestElement>>list(_left, _right);
+        final Iterable<Function1<TestSuiteElement, ? extends TestElement>> elements = IterableExtensions.<Function1<TestSuiteElement, ? extends TestElement>>filterNull(_list);
+        Matcher<String> _result = it.getResult();
+        TestSuiteElement _root = AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.this.root(((Function1<? super TestSuiteElement, ? extends TestElement>[])Conversions.unwrapArray(elements, Function1.class)));
+        String _label = AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.this.label(_root);
+        boolean _matches = _result.matches(_label);
+        Assert.assertTrue("\nExpected result.matches(label(root(elements))) should be true but"
+         + "\n     result.matches(label(root(elements))) is " + new org.hamcrest.StringDescription().appendValue(Boolean.valueOf(_matches)).toString()
+         + "\n     result is " + new org.hamcrest.StringDescription().appendValue(_result).toString()
+         + "\n     label(root(elements)) is " + new org.hamcrest.StringDescription().appendValue(_label).toString()
+         + "\n     root(elements) is " + new org.hamcrest.StringDescription().appendValue(_root).toString()
+         + "\n     elements is " + new org.hamcrest.StringDescription().appendValue(((Function1<? super TestSuiteElement, ? extends TestElement>[])Conversions.unwrapArray(elements, Function1.class))).toString() + "\n", Should.<Boolean>should_be(Boolean.valueOf(_matches), true));
+        
+      }
+    };
+    Each.<AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases>forEach(this.cases, _function);
+  }
+  
+  public TestSuiteElement root(final Function1<? super TestSuiteElement, ? extends TestElement>... elementConstructors) {
+    Function1<TestSuiteElement, TestSuiteElement> _suite = this.suite(elementConstructors);
+    return _suite.apply(this.root);
+  }
+  
+  public Function1<TestSuiteElement, TestSuiteElement> suite(final Function1<? super TestSuiteElement, ? extends TestElement>... elementConstructors) {
+    final Function1<TestSuiteElement, TestSuiteElement> _function = new Function1<TestSuiteElement, TestSuiteElement>() {
+      public TestSuiteElement apply(final TestSuiteElement parent) {
+        TestSuiteElement _xblockexpression = null;
+        {
+          final TestSuiteElement suite = new TestSuiteElement(parent, "id", "name", 10);
+          final Procedure1<Function1<? super TestSuiteElement, ? extends TestElement>> _function = new Procedure1<Function1<? super TestSuiteElement, ? extends TestElement>>() {
+            public void apply(final Function1<? super TestSuiteElement, ? extends TestElement> it) {
+              it.apply(suite);
+            }
+          };
+          IterableExtensions.<Function1<? super TestSuiteElement, ? extends TestElement>>forEach(((Iterable<Function1<? super TestSuiteElement, ? extends TestElement>>)Conversions.doWrapArray(elementConstructors)), _function);
+          _xblockexpression = suite;
+        }
+        return _xblockexpression;
+      }
+    };
+    return _function;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> tc() {
+    final Function1<TestSuiteElement, TestCaseElement> _function = new Function1<TestSuiteElement, TestCaseElement>() {
+      public TestCaseElement apply(final TestSuiteElement suite) {
+        return new TestCaseElement(suite, "id", "tc");
+      }
+    };
+    return _function;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> ign() {
+    final Function1<TestSuiteElement, TestCaseElement> _function = new Function1<TestSuiteElement, TestCaseElement>() {
+      public TestCaseElement apply(final TestSuiteElement suite) {
+        Function1<TestSuiteElement, TestCaseElement> _tc = AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.this.tc();
+        TestCaseElement _apply = _tc.apply(suite);
+        final Procedure1<TestCaseElement> _function = new Procedure1<TestCaseElement>() {
+          public void apply(final TestCaseElement it) {
+            it.setName("tc-ign");
+            it.setIgnored(true);
+          }
+        };
+        return ObjectExtensions.<TestCaseElement>operator_doubleArrow(_apply, _function);
+      }
+    };
+    return _function;
+  }
+  
+  public Function1<TestSuiteElement, TestCaseElement> pend() {
+    final Function1<TestSuiteElement, TestCaseElement> _function = new Function1<TestSuiteElement, TestCaseElement>() {
+      public TestCaseElement apply(final TestSuiteElement suite) {
+        Function1<TestSuiteElement, TestCaseElement> _ign = AbstractJnarioRunnerUIHandlerSuiteLabellingSpec.this.ign();
+        TestCaseElement _apply = _ign.apply(suite);
+        final Procedure1<TestCaseElement> _function = new Procedure1<TestCaseElement>() {
+          public void apply(final TestCaseElement it) {
+            it.setName("tc [PENDING]");
+          }
+        };
+        return ObjectExtensions.<TestCaseElement>operator_doubleArrow(_apply, _function);
+      }
+    };
+    return _function;
+  }
+  
+  public String label(final TestSuiteElement suite) {
+    return this.handler.getSimpleLabel(this.part, suite);
+  }
+  
+  public Matcher<String> markedPending() {
+    Matcher<String> _containsString = Matchers.containsString(Strings.PENDING_FLAG);
+    Matcher<String> _containsString_1 = Matchers.containsString(Strings.IGNORED_FLAG);
+    Matcher<String> _not = Matchers.<String>not(_containsString_1);
+    return Matchers.<String>allOf(_containsString, _not);
+  }
+  
+  public Matcher<String> markedIgnored() {
+    Matcher<String> _containsString = Matchers.containsString(Strings.IGNORED_FLAG);
+    Matcher<String> _containsString_1 = Matchers.containsString(Strings.PENDING_FLAG);
+    Matcher<String> _not = Matchers.<String>not(_containsString_1);
+    return Matchers.<String>allOf(_containsString, _not);
+  }
+  
+  public Matcher<String> notMarked() {
+    Matcher<String> _containsString = Matchers.containsString(Strings.IGNORED_FLAG);
+    Matcher<String> _containsString_1 = Matchers.containsString(Strings.PENDING_FLAG);
+    AnyOf<String> _anyOf = Matchers.<String>anyOf(_containsString, _containsString_1);
+    return Matchers.<String>not(_anyOf);
+  }
+}

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases.java
@@ -1,0 +1,38 @@
+package org.jnario.jnario.tests.unit.ui;
+
+import java.util.List;
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.model.TestElement;
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.hamcrest.Matcher;
+import org.jnario.lib.ExampleTableRow;
+
+@SuppressWarnings("all")
+public class AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases extends ExampleTableRow {
+  public AbstractJnarioRunnerUIHandlerSuiteLabellingSpecCases(final List<String> cellNames, final Function1<TestSuiteElement, ? extends TestElement> left, final Function1<TestSuiteElement, TestCaseElement> right, final Matcher<String> result) {
+    super(cellNames);
+    this.left = left;
+    this.right = right;
+    this.result = result;
+    
+  }
+  
+  private Function1<TestSuiteElement, ? extends TestElement> left;
+  
+  public Function1<TestSuiteElement, ? extends TestElement> getLeft() {
+    return this.left;
+  }
+  
+  private Function1<TestSuiteElement, TestCaseElement> right;
+  
+  public Function1<TestSuiteElement, TestCaseElement> getRight() {
+    return this.right;
+  }
+  
+  private Matcher<String> result;
+  
+  public Matcher<String> getResult() {
+    return this.result;
+  }
+}

--- a/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/TestUIHandler.java
+++ b/tests/org.jnario.tests/xtend-gen/org/jnario/jnario/tests/unit/ui/TestUIHandler.java
@@ -1,0 +1,13 @@
+package org.jnario.jnario.tests.unit.ui;
+
+import org.eclipse.jdt.junit.model.ITestElement;
+import org.eclipse.jface.action.Action;
+import org.eclipse.ui.part.ViewPart;
+import org.jnario.ui.handler.AbstractJnarioRunnerUIHandler;
+
+@SuppressWarnings("all")
+public class TestUIHandler extends AbstractJnarioRunnerUIHandler {
+  public Action getAction(final ViewPart part, final ITestElement element) {
+    return null;
+  }
+}


### PR DESCRIPTION
Propagate ignored/pending status up through suite elements in the Eclipse test runner:
- Suites with all elements ignored are marked as [IGNORED]
- Suites with all elements ignored and at least one pending are marked as [PENDING]
- Ignored/pending status propagates through suite elements as well

Fixes #45
